### PR TITLE
Update JWT Expiry to 10 Days

### DIFF
--- a/libs/auth-be/src/lib/services/jwt.service.ts
+++ b/libs/auth-be/src/lib/services/jwt.service.ts
@@ -9,7 +9,7 @@ export class JWTService {
 
   private readonly JWT_ALGORITHM: SignOptions["algorithm"] = "HS512";
 
-  private readonly TOKEN_EXPIRES_IN: string = "7d";
+  private readonly TOKEN_EXPIRES_IN: string = "10d";
 
   private logger = new Logger(JWTService.name);
 


### PR DESCRIPTION
## Overview

This update modifies the JWT expiration period from 7 days to 10 days in the `JWTService`. The change ensures tokens remain valid for a longer duration, enhancing user experience by reducing the frequency of token refresh.

## Changes Made
- Updated the `TOKEN_EXPIRES_IN` from `"7d"` to `"10d"` in `jwt.service.ts`

## Impact
This change will affect all JWT tokens issued by the `JWTService` moving forward. Existing tokens will not be impacted, but all newly generated tokens will have the updated expiration time.

## Testing
Ensure to test the token generation and validation processes to verify the new expiration setting works as intended.