### PR TITLE
Remove Logger from Authentication Middleware

### DIFF
--- a/libs/auth-be/src/lib/services/authentication.middleware.ts
+++ b/libs/auth-be/src/lib/services/authentication.middleware.ts
@@ -1,7 +1,6 @@
 import {
   Injectable,
   NestMiddleware,
-  Logger,
   HttpException,
 } from "@nestjs/common";
 import { Response } from "express";
@@ -13,7 +12,6 @@ import { Repository } from "typeorm";
 
 @Injectable()
 export class AuthenticationMiddleware implements NestMiddleware {
-  private logger = new Logger(AuthenticationMiddleware.name);
 
   constructor(
     @InjectRepository(UserEntity)
@@ -23,11 +21,9 @@ export class AuthenticationMiddleware implements NestMiddleware {
 
   // TODO: use express req type
   async use(req: any, res: Response, next: (error?: unknown) => void) {
-    this.logger.log("Running auth middleware");
     try {
       const jwt: string = req.cookies.token || "";
       req["authUser"] = await this.fetchUserDetails(jwt);
-      this.logger.log(`User ${req["authUser"].name} is authenticated`);
       next();
     } catch (err) {
       if (err instanceof JsonWebTokenError) {


### PR DESCRIPTION
### Summary
This pull request removes the Logger from the `AuthenticationMiddleware` class located in `libs/auth-be/src/lib/services/authentication.middleware.ts`. This change eliminates the logging of messages when the middleware is running and when a user is successfully authenticated.

### Changes
- Removed the `Logger` instance from the class.
- Deleted the log statements: 
  - `"Running auth middleware"`
  - `"User ${req[\"authUser\"].name} is authenticated"`

### Impact
These changes will prevent unnecessary logging related to user authentication in the middleware, which can streamline logging outputs and improve performance slightly if logging had a noticeable impact.

### Testing
Ensure that the authentication process works as expected without the log statements. All existing tests should pass without modification.