### PR TITLE
Remove Logger Statement from Authentication Middleware

### DIFF
--- a/libs/auth-be/src/lib/services/authentication.middleware.ts
+++ b/libs/auth-be/src/lib/services/authentication.middleware.ts
@@ -27,7 +27,7 @@ export class AuthenticationMiddleware implements NestMiddleware {
     try {
       const jwt: string = req.cookies.token || "";
       req["authUser"] = await this.fetchUserDetails(jwt);
-      this.logger.log(`User ${req["authUser"].name} is authenticated`);
+      // Logger statement removed
       next();
     } catch (err) {
       if (err instanceof JsonWebTokenError) {


### PR DESCRIPTION
### Summary
This pull request removes the logger statement in the `AuthenticationMiddleware` class that was logging when a user is authenticated.

### Details
- Removed the logger statement: `this.logger.log(`User ${req["authUser"].name} is authenticated`);`
- This cleanup helps in reducing unnecessary log clutter related to authentication.

### Impact
This change will ensure that user authentication logs are not cluttered in the application, making logs more efficient and readable.