### PR TITLE
Update GitHub Login Label to Signin

### DIFF
--- a/apps/frontend/src/app/modules/landing-page/components/landing-page.component.html
+++ b/apps/frontend/src/app/modules/landing-page/components/landing-page.component.html
@@ -4,7 +4,7 @@
       *ngIf="(isUserAuthenticated$ | async) === false; else authUser"
       class="login-section"
     >
-      <a [href]="ghAuthorizeEndpoint">Login with Github</a>
+      <a [href]="ghAuthorizeEndpoint">Signin with Github</a>
     </div>
     <ng-template #authUser>
       <p>Welcome, {{ (userProfile$ | async)?.name }}!</p>


### PR DESCRIPTION
### Changes Made
- Updated the label "Login with Github" to "Signin with Github" in the landing page component.

### Reason
- Aligning the terminology to be more consistent with common authentication language.

### File Updated
- `landing-page.component.html`: Changed anchor text to "Signin with Github".

Please review the changes and merge into the main branch.